### PR TITLE
Fixes issue #143 opened by @rberger

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/format/common/DateTimeAttribute.java
+++ b/src/main/java/com/github/fge/jsonschema/format/common/DateTimeAttribute.java
@@ -42,13 +42,13 @@ public final class DateTimeAttribute
     extends AbstractFormatAttribute
 {
     private static final List<String> FORMATS = ImmutableList.of(
-        "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}Z"
     );
     private static final DateTimeFormatter FORMATTER;
 
     static {
-        final DateTimeParser msParser = new DateTimeFormatterBuilder()
-            .appendLiteral('.').appendDecimal(millisOfSecond(), 1, 3)
+        final DateTimeParser secFracsParser = new DateTimeFormatterBuilder()
+            .appendLiteral('.').appendFractionOfSecond(1,12)
             .toParser();
 
         DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
@@ -64,7 +64,7 @@ public final class DateTimeAttribute
             .appendFixedDecimal(minuteOfHour(), 2)
             .appendLiteral(':')
             .appendFixedDecimal(secondOfMinute(), 2)
-            .appendOptional(msParser)
+            .appendOptional(secFracsParser)
             .appendTimeZoneOffset("Z", false, 2, 2);
 
         FORMATTER = builder.toFormatter();

--- a/src/test/resources/format/common/date-time.json
+++ b/src/test/resources/format/common/date-time.json
@@ -25,7 +25,7 @@
         "message": "err.format.invalidDate",
         "msgData": {
             "value": "2012-02-30T00:00:00+0000",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSZ" ]
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}Z" ]
         },
         "msgParams": [ "value", "expected" ]
     },
@@ -35,8 +35,48 @@
         "message": "err.format.invalidDate",
         "msgData": {
             "value": "201202030",
-            "expected": [ "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSZ" ]
+            "expected": [ "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}Z" ]
         },
         "msgParams": [ "value", "expected" ]
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234567Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345678Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345678Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456789Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.1234567890Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.12345678901Z",
+      "valid": true
+    },
+    {
+      "data": "2012-08-07T20:42:32.123456789012Z",
+      "valid": true
     }
 ]


### PR DESCRIPTION
The secFracs optional field will now support upto 12 digits.
The static class Fraction, in DateTimeFormatterBuilder, limits the max digits to 18. However as i was not able to find any upper limit for this field except in some database, i have set this limit to 12 digits.
The error message has been updated accordingly.
