### PR TITLE
Switch KeywordValidators to use a factory model

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/keyword/validator/KeywordValidatorFactory.java
+++ b/src/main/java/com/github/fge/jsonschema/keyword/validator/KeywordValidatorFactory.java
@@ -1,0 +1,20 @@
+package com.github.fge.jsonschema.keyword.validator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+
+/**
+ * Interface for a keyword validator factory
+ */
+public interface KeywordValidatorFactory
+{
+    /**
+     * Create a validator for the instance
+     *
+     * @param node the instance to validate
+     * @return a validator for the given instance
+     * @throws ProcessingException an error occurs creating the validator
+     */
+    KeywordValidator getKeywordValidator(JsonNode node)
+            throws ProcessingException;
+}

--- a/src/main/java/com/github/fge/jsonschema/keyword/validator/ReflectionKeywordValidatorFactory.java
+++ b/src/main/java/com/github/fge/jsonschema/keyword/validator/ReflectionKeywordValidatorFactory.java
@@ -1,0 +1,52 @@
+package com.github.fge.jsonschema.keyword.validator;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.messages.JsonSchemaConfigurationBundle;
+import com.github.fge.msgsimple.bundle.MessageBundle;
+import com.github.fge.msgsimple.load.MessageBundles;
+
+/**
+ * A validator factory that uses reflection to create an instance of the
+ * specified KeywordValidator class
+ */
+public class ReflectionKeywordValidatorFactory
+    implements KeywordValidatorFactory
+{
+    private static final String ERRMSG = "failed to build keyword validator";
+    private static final MessageBundle BUNDLE
+        = MessageBundles.getBundle(JsonSchemaConfigurationBundle.class);
+
+    private final Constructor<? extends KeywordValidator> constructor;
+
+    public ReflectionKeywordValidatorFactory(String name,
+        Class<? extends KeywordValidator> clazz)
+    {
+        try {
+            constructor = clazz.getConstructor(JsonNode.class);
+        } catch (NoSuchMethodException ignored) {
+            throw new IllegalArgumentException(BUNDLE.printf(
+                "noAppropriateConstructor", name, clazz.getCanonicalName()
+            ));
+        }
+    }
+
+    @Override
+    public KeywordValidator getKeywordValidator(JsonNode node)
+        throws ProcessingException
+    {
+        try {
+            return constructor.newInstance(node);
+        } catch (InstantiationException e) {
+            throw new ProcessingException(ERRMSG, e);
+        } catch (IllegalAccessException e) {
+            throw new ProcessingException(ERRMSG, e);
+        } catch (InvocationTargetException e) {
+            throw new ProcessingException(ERRMSG, e);
+        }
+    }
+
+}

--- a/src/main/java/com/github/fge/jsonschema/library/Keyword.java
+++ b/src/main/java/com/github/fge/jsonschema/library/Keyword.java
@@ -22,9 +22,7 @@ package com.github.fge.jsonschema.library;
 import com.github.fge.Frozen;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.SyntaxChecker;
 import com.github.fge.jsonschema.keyword.digest.Digester;
-import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
-
-import java.lang.reflect.Constructor;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
 
 
 /**
@@ -51,9 +49,9 @@ public final class Keyword
     final Digester digester;
 
     /**
-     * {@link KeywordValidator} constructor
+     * Validator factory
      */
-    final Constructor<? extends KeywordValidator> constructor;
+    final KeywordValidatorFactory validatorFactory;
 
     /**
      * Instantiate a new keyword builder
@@ -79,7 +77,7 @@ public final class Keyword
         name = builder.name;
         syntaxChecker = builder.syntaxChecker;
         digester = builder.digester;
-        constructor = builder.constructor;
+        validatorFactory = builder.validatorFactory;
     }
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/library/Library.java
+++ b/src/main/java/com/github/fge/jsonschema/library/Library.java
@@ -26,9 +26,7 @@ import com.github.fge.jsonschema.core.keyword.syntax.checkers.SyntaxChecker;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.format.FormatAttribute;
 import com.github.fge.jsonschema.keyword.digest.Digester;
-import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
-
-import java.lang.reflect.Constructor;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
 
 /**
  * A schema keyword library
@@ -54,9 +52,9 @@ public final class Library
     final Dictionary<Digester> digesters;
 
     /**
-     * Dictionary of keyword validator constructors
+     * Dictionary of keyword validator factories
      */
-    final Dictionary<Constructor<? extends KeywordValidator>> validators;
+    final Dictionary<KeywordValidatorFactory> validators;
 
     /**
      * Dictionary of format attributes
@@ -97,7 +95,7 @@ public final class Library
      */
     Library(final Dictionary<SyntaxChecker> syntaxCheckers,
         final Dictionary<Digester> digesters,
-        final Dictionary<Constructor<? extends KeywordValidator>> validators,
+        final Dictionary<KeywordValidatorFactory> validators,
         final Dictionary<FormatAttribute> formatAttributes)
     {
         this.syntaxCheckers = syntaxCheckers;
@@ -131,7 +129,7 @@ public final class Library
      *
      * @return a dictionary
      */
-    public Dictionary<Constructor<? extends KeywordValidator>> getValidators()
+    public Dictionary<KeywordValidatorFactory> getValidators()
     {
         return validators;
     }

--- a/src/main/java/com/github/fge/jsonschema/library/LibraryBuilder.java
+++ b/src/main/java/com/github/fge/jsonschema/library/LibraryBuilder.java
@@ -25,12 +25,10 @@ import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.format.FormatAttribute;
 import com.github.fge.jsonschema.keyword.digest.Digester;
-import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
 import com.github.fge.jsonschema.messages.JsonSchemaConfigurationBundle;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-
-import java.lang.reflect.Constructor;
 
 /**
  * Mutable version of a library
@@ -60,7 +58,7 @@ public final class LibraryBuilder
     /**
      * Dictionary builder of keyword validator constructors
      */
-    final DictionaryBuilder<Constructor<? extends KeywordValidator>> validators;
+    final DictionaryBuilder<KeywordValidatorFactory> validators;
 
     /**
      * Dictionary builder of format attributes
@@ -107,9 +105,9 @@ public final class LibraryBuilder
 
         syntaxCheckers.addEntry(name, keyword.syntaxChecker);
 
-        if (keyword.constructor != null) {
+        if (keyword.validatorFactory != null) {
             digesters.addEntry(name, keyword.digester);
-            validators.addEntry(name, keyword.constructor);
+            validators.addEntry(name, keyword.validatorFactory);
         }
         return this;
     }

--- a/src/main/java/com/github/fge/jsonschema/library/validator/CommonValidatorDictionary.java
+++ b/src/main/java/com/github/fge/jsonschema/library/validator/CommonValidatorDictionary.java
@@ -19,10 +19,11 @@
 
 package com.github.fge.jsonschema.library.validator;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
+import com.github.fge.jsonschema.keyword.validator.ReflectionKeywordValidatorFactory;
 import com.github.fge.jsonschema.keyword.validator.common.AdditionalItemsValidator;
 import com.github.fge.jsonschema.keyword.validator.common.AdditionalPropertiesValidator;
 import com.github.fge.jsonschema.keyword.validator.common.EnumValidator;
@@ -35,27 +36,25 @@ import com.github.fge.jsonschema.keyword.validator.common.MinimumValidator;
 import com.github.fge.jsonschema.keyword.validator.common.PatternValidator;
 import com.github.fge.jsonschema.keyword.validator.common.UniqueItemsValidator;
 
-import java.lang.reflect.Constructor;
-
 /**
  * Keyword validator constructors common to draft v4 and v3
  */
 public final class CommonValidatorDictionary
 {
-    private static final Dictionary<Constructor<? extends KeywordValidator>>
+    private static final Dictionary<KeywordValidatorFactory>
         DICTIONARY;
 
     private CommonValidatorDictionary()
     {
     }
 
-    public static Dictionary<Constructor<? extends KeywordValidator>> get()
+    public static Dictionary<KeywordValidatorFactory> get()
     {
         return DICTIONARY;
     }
 
     static {
-        final DictionaryBuilder<Constructor<? extends KeywordValidator>>
+        final DictionaryBuilder<KeywordValidatorFactory>
             builder = Dictionary.newBuilder();
 
         String keyword;
@@ -66,67 +65,63 @@ public final class CommonValidatorDictionary
          */
         keyword = "additionalItems";
         c = AdditionalItemsValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "minItems";
         c = MinItemsValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "maxItems";
         c = MaxItemsValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "uniqueItems";
         c = UniqueItemsValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         /*
          * Numbers and integers
          */
         keyword = "minimum";
         c = MinimumValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "maximum";
         c = MaximumValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         /*
          * Objects
          */
         keyword = "additionalProperties";
         c = AdditionalPropertiesValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         /*
          * Strings
          */
         keyword = "minLength";
         c = MinLengthValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "maxLength";
         c = MaxLengthValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "pattern";
         c = PatternValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "enum";
         c = EnumValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         DICTIONARY = builder.freeze();
     }
 
-    private static Constructor<? extends KeywordValidator> constructor(
+    private static KeywordValidatorFactory factory(String name,
         final Class<? extends KeywordValidator> c)
     {
-        try {
-            return c.getConstructor(JsonNode.class);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("No appropriate constructor", e);
-        }
+        return new ReflectionKeywordValidatorFactory(name, c);
     }
 }

--- a/src/main/java/com/github/fge/jsonschema/library/validator/DraftV3ValidatorDictionary.java
+++ b/src/main/java/com/github/fge/jsonschema/library/validator/DraftV3ValidatorDictionary.java
@@ -19,10 +19,11 @@
 
 package com.github.fge.jsonschema.library.validator;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
+import com.github.fge.jsonschema.keyword.validator.ReflectionKeywordValidatorFactory;
 import com.github.fge.jsonschema.keyword.validator.common.DependenciesValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv3.DisallowKeywordValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv3.DivisibleByValidator;
@@ -30,27 +31,25 @@ import com.github.fge.jsonschema.keyword.validator.draftv3.DraftV3TypeValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv3.ExtendsValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv3.PropertiesValidator;
 
-import java.lang.reflect.Constructor;
-
 /**
  * Draft v3 specific keyword validator constructors
  */
 public final class DraftV3ValidatorDictionary
 {
-    private static final Dictionary<Constructor<? extends KeywordValidator>>
+    private static final Dictionary<KeywordValidatorFactory>
         DICTIONARY;
 
     private DraftV3ValidatorDictionary()
     {
     }
 
-    public static Dictionary<Constructor<? extends KeywordValidator>> get()
+    public static Dictionary<KeywordValidatorFactory> get()
     {
         return DICTIONARY;
     }
 
     static {
-        final DictionaryBuilder<Constructor<? extends KeywordValidator>>
+        final DictionaryBuilder<KeywordValidatorFactory>
             builder = Dictionary.newBuilder();
 
         String keyword;
@@ -63,41 +62,37 @@ public final class DraftV3ValidatorDictionary
          */
         keyword = "divisibleBy";
         c = DivisibleByValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         /*
          * Object
          */
         keyword = "properties";
         c = PropertiesValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "dependencies";
         c = DependenciesValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "type";
         c = DraftV3TypeValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "disallow";
         c = DisallowKeywordValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "extends";
         c = ExtendsValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         DICTIONARY = builder.freeze();
     }
 
-    private static Constructor<? extends KeywordValidator> constructor(
+    private static KeywordValidatorFactory factory(String name,
         final Class<? extends KeywordValidator> c)
     {
-        try {
-            return c.getConstructor(JsonNode.class);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("No appropriate constructor found", e);
-        }
+        return new ReflectionKeywordValidatorFactory(name, c);
     }
 }

--- a/src/main/java/com/github/fge/jsonschema/library/validator/DraftV4ValidatorDictionary.java
+++ b/src/main/java/com/github/fge/jsonschema/library/validator/DraftV4ValidatorDictionary.java
@@ -19,10 +19,11 @@
 
 package com.github.fge.jsonschema.library.validator;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
+import com.github.fge.jsonschema.keyword.validator.ReflectionKeywordValidatorFactory;
 import com.github.fge.jsonschema.keyword.validator.common.DependenciesValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv4.AllOfValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv4.AnyOfValidator;
@@ -34,27 +35,25 @@ import com.github.fge.jsonschema.keyword.validator.draftv4.NotValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv4.OneOfValidator;
 import com.github.fge.jsonschema.keyword.validator.draftv4.RequiredKeywordValidator;
 
-import java.lang.reflect.Constructor;
-
 /**
  * Draft v4 specific keyword validator constructors
  */
 public final class DraftV4ValidatorDictionary
 {
-    private static final Dictionary<Constructor<? extends KeywordValidator>>
+    private static final Dictionary<KeywordValidatorFactory>
         DICTIONARY;
 
     private DraftV4ValidatorDictionary()
     {
     }
 
-    public static Dictionary<Constructor<? extends KeywordValidator>> get()
+    public static Dictionary<KeywordValidatorFactory> get()
     {
         return DICTIONARY;
     }
 
     static {
-        final DictionaryBuilder<Constructor<? extends KeywordValidator>>
+        final DictionaryBuilder<KeywordValidatorFactory>
             builder = Dictionary.newBuilder();
 
         String keyword;
@@ -67,60 +66,56 @@ public final class DraftV4ValidatorDictionary
          */
         keyword = "multipleOf";
         c = MultipleOfValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         /*
          * Object
          */
         keyword = "minProperties";
         c = MinPropertiesValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "maxProperties";
         c = MaxPropertiesValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "required";
         c = RequiredKeywordValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "dependencies";
         c = DependenciesValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         /*
          * All
          */
         keyword = "anyOf";
         c = AnyOfValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "allOf";
         c = AllOfValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "oneOf";
         c = OneOfValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "not";
         c = NotValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         keyword = "type";
         c = DraftV4TypeValidator.class;
-        builder.addEntry(keyword, constructor(c));
+        builder.addEntry(keyword, factory(keyword, c));
 
         DICTIONARY = builder.freeze();
     }
 
-    private static Constructor<? extends KeywordValidator> constructor(
+    private static KeywordValidatorFactory factory(String name,
         final Class<? extends KeywordValidator> c)
     {
-        try {
-            return c.getConstructor(JsonNode.class);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("No appropriate constructor found", e);
-        }
+        return new ReflectionKeywordValidatorFactory(name, c);
     }
 }

--- a/src/test/java/com/github/fge/jsonschema/keyword/special/ExtendsKeywordTest.java
+++ b/src/test/java/com/github/fge/jsonschema/keyword/special/ExtendsKeywordTest.java
@@ -19,6 +19,19 @@
 
 package com.github.fge.jsonschema.keyword.special;
 
+import static com.github.fge.jsonschema.TestUtils.anyMessage;
+import static com.github.fge.jsonschema.matchers.ProcessingMessageAssert.assertMessage;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jackson.JacksonUtils;
@@ -33,22 +46,12 @@ import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.jsonschema.core.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.core.tree.key.SchemaKey;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
 import com.github.fge.jsonschema.library.validator.DraftV3ValidatorDictionary;
 import com.github.fge.jsonschema.messages.JsonSchemaValidationBundle;
 import com.github.fge.jsonschema.processors.data.FullData;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import org.mockito.ArgumentCaptor;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
-import static com.github.fge.jsonschema.TestUtils.*;
-import static com.github.fge.jsonschema.matchers.ProcessingMessageAssert.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 
 public final class ExtendsKeywordTest
 {
@@ -65,13 +68,12 @@ public final class ExtendsKeywordTest
     private ProcessingMessage msg;
 
     public ExtendsKeywordTest()
-        throws IllegalAccessException, InvocationTargetException,
-        InstantiationException
+        throws ProcessingException
     {
-        final Constructor<? extends KeywordValidator> constructor
+        final KeywordValidatorFactory factory
             = DraftV3ValidatorDictionary.get().entries().get("extends");
-        validator = constructor == null ? null
-            : constructor.newInstance(FACTORY.nullNode());
+        validator = factory == null ? null
+            : factory.getKeywordValidator(FACTORY.nullNode());
     }
 
     @BeforeMethod

--- a/src/test/java/com/github/fge/jsonschema/keyword/special/NotKeywordTest.java
+++ b/src/test/java/com/github/fge/jsonschema/keyword/special/NotKeywordTest.java
@@ -19,6 +19,20 @@
 
 package com.github.fge.jsonschema.keyword.special;
 
+import static com.github.fge.jsonschema.TestUtils.anyMessage;
+import static com.github.fge.jsonschema.matchers.ProcessingMessageAssert.assertMessage;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jackson.JacksonUtils;
@@ -34,22 +48,12 @@ import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.jsonschema.core.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.core.tree.key.SchemaKey;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
 import com.github.fge.jsonschema.library.validator.DraftV4ValidatorDictionary;
 import com.github.fge.jsonschema.messages.JsonSchemaValidationBundle;
 import com.github.fge.jsonschema.processors.data.FullData;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import org.mockito.ArgumentCaptor;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-
-import static com.github.fge.jsonschema.TestUtils.*;
-import static com.github.fge.jsonschema.matchers.ProcessingMessageAssert.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 
 public final class NotKeywordTest
 {
@@ -65,13 +69,12 @@ public final class NotKeywordTest
     private ProcessingReport report;
 
     public NotKeywordTest()
-        throws IllegalAccessException, InvocationTargetException,
-        InstantiationException
+        throws ProcessingException
     {
-        final Constructor<? extends KeywordValidator> constructor
+        final KeywordValidatorFactory factory
             = DraftV4ValidatorDictionary.get().entries().get("not");
-        validator = constructor == null ? null
-            : constructor.newInstance(FACTORY.nullNode());
+        validator = factory == null ? null
+            : factory.getKeywordValidator(FACTORY.nullNode());
     }
 
     @BeforeMethod

--- a/src/test/java/com/github/fge/jsonschema/keyword/special/PatternKeywordTest.java
+++ b/src/test/java/com/github/fge/jsonschema/keyword/special/PatternKeywordTest.java
@@ -19,6 +19,22 @@
 
 package com.github.fge.jsonschema.keyword.special;
 
+import static com.github.fge.jsonschema.TestUtils.anyMessage;
+import static com.github.fge.jsonschema.matchers.ProcessingMessageAssert.assertMessage;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
+import java.util.List;
+
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jackson.JsonLoader;
@@ -33,26 +49,13 @@ import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.jsonschema.core.tree.SimpleJsonTree;
 import com.github.fge.jsonschema.core.tree.key.SchemaKey;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
 import com.github.fge.jsonschema.library.validator.CommonValidatorDictionary;
 import com.github.fge.jsonschema.messages.JsonSchemaValidationBundle;
 import com.github.fge.jsonschema.processors.data.FullData;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
 import com.google.common.collect.Lists;
-import org.mockito.ArgumentCaptor;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Iterator;
-import java.util.List;
-
-import static com.github.fge.jsonschema.TestUtils.*;
-import static com.github.fge.jsonschema.matchers.ProcessingMessageAssert.*;
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 
 public final class PatternKeywordTest
 {
@@ -65,20 +68,20 @@ public final class PatternKeywordTest
     private static final MessageBundle BUNDLE
         = MessageBundles.getBundle(JsonSchemaValidationBundle.class);
 
-    private final Constructor<? extends KeywordValidator> constructor;
+    private final KeywordValidatorFactory factory;
     private final JsonNode testData;
 
     public PatternKeywordTest()
         throws IOException
     {
-        constructor = CommonValidatorDictionary.get().entries().get("pattern");
+        factory = CommonValidatorDictionary.get().entries().get("pattern");
         testData = JsonLoader.fromResource("/keyword/special/pattern.json");
     }
 
     @Test
     public void keywordExists()
     {
-        assertNotNull(constructor, "no support for pattern??");
+        assertNotNull(factory, "no support for pattern??");
     }
 
     @DataProvider
@@ -120,7 +123,7 @@ public final class PatternKeywordTest
 
         // It is a null node which is ignored by the constructor, so we can
         // do that
-        final KeywordValidator validator = constructor.newInstance(schema);
+        final KeywordValidator validator = factory.getKeywordValidator(schema);
         validator.validate(processor, report, BUNDLE, data);
 
         if (valid) {

--- a/src/test/java/com/github/fge/jsonschema/processors/build/ValidatorBuilderTest.java
+++ b/src/test/java/com/github/fge/jsonschema/processors/build/ValidatorBuilderTest.java
@@ -19,6 +19,16 @@
 
 package com.github.fge.jsonschema.processors.build;
 
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JacksonUtils;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -27,20 +37,14 @@ import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.util.Dictionary;
 import com.github.fge.jsonschema.core.util.DictionaryBuilder;
 import com.github.fge.jsonschema.keyword.validator.KeywordValidator;
+import com.github.fge.jsonschema.keyword.validator.KeywordValidatorFactory;
+import com.github.fge.jsonschema.keyword.validator.ReflectionKeywordValidatorFactory;
 import com.github.fge.jsonschema.processors.data.FullData;
 import com.github.fge.jsonschema.processors.data.SchemaDigest;
 import com.github.fge.jsonschema.processors.data.ValidatorList;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.testng.annotations.Test;
-
-import java.lang.reflect.Constructor;
-import java.util.List;
-import java.util.Map;
-
-import static org.mockito.Mockito.*;
-import static org.testng.Assert.*;
 
 public final class ValidatorBuilderTest
 {
@@ -53,17 +57,17 @@ public final class ValidatorBuilderTest
     public ValidatorBuilderTest()
         throws NoSuchMethodException
     {
-        final DictionaryBuilder<Constructor<? extends KeywordValidator>>
+        final DictionaryBuilder<KeywordValidatorFactory>
             builder = Dictionary.newBuilder();
 
-        Constructor<? extends KeywordValidator> constructor;
+        KeywordValidatorFactory factory;
 
-        constructor = Keyword1.class .getConstructor(JsonNode.class);
-        builder.addEntry(K1, constructor);
-        constructor = Keyword2.class.getConstructor(JsonNode.class);
-        builder.addEntry(K2, constructor);
-        constructor = Challenged.class.getConstructor(JsonNode.class);
-        builder.addEntry(CHALLENGED, constructor);
+        factory = new ReflectionKeywordValidatorFactory(K1, Keyword1.class);
+        builder.addEntry(K1, factory);
+        factory = new ReflectionKeywordValidatorFactory(K2, Keyword2.class);
+        builder.addEntry(K2, factory);
+        factory = new ReflectionKeywordValidatorFactory(CHALLENGED, Challenged.class);
+        builder.addEntry(CHALLENGED, factory);
 
         validatorBuilder = new ValidatorBuilder(builder.freeze());
     }


### PR DESCRIPTION
The current method of specifying a `KeywordValidator` places arbitrary restrictions on the visibility and structure of the validator class.

Switch this to use a factory model so the validator classes can be written however the developer desires.

This includes `ReflectionKeywordValidatorFactory` which mimics the old behavior.
